### PR TITLE
Remove st2client dependency

### DIFF
--- a/lib/stackstorm_api.py
+++ b/lib/stackstorm_api.py
@@ -67,9 +67,6 @@ class StackStormAPI(object):
     def match(self, text, st2token):
         headers = st2token.requests()
 
-        if LOG.level <= logging.DEBUG:
-            headers['debug'] = True
-
         url = "/".join([self.cfg.api_url, "actionalias/match"])
         payload = json.dumps({"command": text})
 

--- a/lib/stackstorm_api.py
+++ b/lib/stackstorm_api.py
@@ -66,16 +66,17 @@ class StackStormAPI(object):
 
     def match(self, text, st2token):
         headers = st2token.requests()
-
         url = "/".join([self.cfg.api_url, "actionalias/match"])
+
         payload = json.dumps({"command": text})
+        headers["Content-Type"] = "application/json"
 
         result = Result()
         try:
             response = requests.post(
                 url,
                 headers=headers,
-                json=payload,
+                data=payload,
                 verify=self.cfg.verify_cert
             )
             if response.status_code == 200:

--- a/lib/stackstorm_api.py
+++ b/lib/stackstorm_api.py
@@ -107,7 +107,7 @@ class StackStormAPI(object):
         """
         headers = st2token.requests()
 
-        url = "/".join(self.cfg.api_url, "aliasexecution/match_and_execute")
+        url = "/".join([self.cfg.api_url, "aliasexecution/match_and_execute"])
 
         payload = {
             "command": msg.body,
@@ -127,7 +127,7 @@ class StackStormAPI(object):
             response = requests.post(
                 url,
                 headers=headers,
-                json=json.loads(payload),
+                json=payload,
                 verify=self.cfg.verify_cert
             )
 

--- a/lib/stackstorm_api.py
+++ b/lib/stackstorm_api.py
@@ -71,7 +71,7 @@ class StackStormAPI(object):
             headers['debug'] = True
 
         url = "/".join([self.cfg.api_url, "actionalias/match"])
-        payload = json.loads({"command": text})
+        payload = json.dumps({"command": text})
 
         result = Result()
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-st2client>=2.9.1
-requests[security]<2.15,>=2.14.1
+requests
 sseclient-py
-sseclient==0.0.19
+sseclient
 keyring
 hvac

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests
+requests>=2.20.0
 sseclient-py
 sseclient
 keyring

--- a/st2.py
+++ b/st2.py
@@ -212,7 +212,9 @@ class St2(BotPlugin):
                     st2token
                 )
                 LOG.debug("action alias execution result: type={} {}".format(type(res), res))
-                result = r"{}".format(res)
+                result = res ["results"][0]["message"]
+                if res["results"][0]["actionalias"]["ack"]["append_url"]:
+                    result = " ".join([result, res["results"][0]["execution"]["web_url"]])
             else:
                 result = "st2 command '{}' is disabled.".format(msg.body)
         else:

--- a/st2.py
+++ b/st2.py
@@ -199,10 +199,11 @@ class St2(BotPlugin):
         LOG.debug("Message received from chat backend.\n{}\n".format(msg_debug))
 
         matched_result = self.st2api.match(msg.body, st2token)
-        if matched_result.error_code == 0:
-            action_alias, representation = matched_result.result
+        if matched_result.return_code == 0:
+            action_alias = matched_result.message["actionalias"]
+            representation = matched_result.message["representation"]
             del matched_result
-            if action_alias.enabled is True:
+            if action_alias["enabled"] is True:
                 res = self.st2api.execute_actionalias(
                     action_alias,
                     representation,
@@ -215,7 +216,7 @@ class St2(BotPlugin):
             else:
                 result = "st2 command '{}' is disabled.".format(msg.body)
         else:
-            result = matched_result.result
+            result = matched_result.message
         return result
 
     @arg_botcmd("--pack", dest="pack", type=str)


### PR DESCRIPTION
To support Rocket.Chat, MatterMost, Gitter, Discord and Slack backend, the st2client module has been dropped to use `requests>=2.20`.