### PR TITLE
Fixes #5 - uses get chain rather than explicit keys.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,11 @@ setuptools.setup(
     name="err-stackstorm",
     version="2.0.0",
     author="Err-StackStorm Plugin contributors",
-    author_email="nobody@localhost",
+    author_email="nzlosh@yahoo.com",
     description="An Errbot plugin for StackStorm ChatOps.",
     long_description="Not available",
     long_description_content_type="text/markdown",
-    url="https://github.com/fmnisme/err-stackstorm",
+    url="https://github.com/nzlosh/err-stackstorm",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/st2.py
+++ b/st2.py
@@ -204,7 +204,7 @@ class St2(BotPlugin):
             action_alias = matched_result.message["actionalias"]
             representation = matched_result.message["representation"]
             del matched_result
-            if action_alias["enabled"] is True:
+            if action_alias.get("enabled", True) is True:
                 res = self.st2api.execute_actionalias(
                     action_alias,
                     representation,
@@ -213,10 +213,24 @@ class St2(BotPlugin):
                     st2token
                 )
                 LOG.debug("action alias execution result: type={} {}".format(type(res), res))
-                if action_alias["ack"]["enabled"]:
-                    result = res ["results"][0]["message"]
-                    if res["results"][0]["actionalias"]["ack"]["append_url"]:
-                        result = " ".join([result, res["results"][0]["execution"]["web_url"]])
+                if "ack" in action_alias:
+                    if action_alias["ack"].get("enabled", True) is True:
+                        result = res.get("results", [{}])[0].get("message", "")
+                        if res.get(
+                            "results", [{}]
+                        )[0].get(
+                            "actionalias",{}
+                        ).get(
+                            "ack", {}
+                        ).get(
+                            "append_url", False
+                        ):
+                            result = " ".join(
+                                [
+                                    result,
+                                    res.get("results",[{}])[0].get("execution").get("web_url", "")
+                                ]
+                            )
             else:
                 result = "st2 command '{}' is disabled.".format(msg.body)
         else:


### PR DESCRIPTION
Avoid raising an exception when optional acknowledge isn't present in action-alias response.