### PR TITLE
Remove unused store adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,7 @@ STACKSTORM = {
     'stream_url': 'https://stackstorm.example.com/stream/v1',
 
     'verify_cert': True,
-    'secrets_store': {
-        'cleartext': {}
-        'keyring': {
-            'keyring_password': "<keyring_password>"
-        },
-        'vault': {}
-    },
+    'secrets_store': 'cleartext',
     'api_auth': {
         'user': {
             'name': 'my_username',
@@ -93,10 +87,6 @@ STACKSTORM = {
     },
     'rbac_auth': {
         'standalone': {},
-        'serverside': {},
-        'clientside': {
-            'url': '<url_to_errbot_webserver>',
-        }
     },
     'timer_update': 900, #  Unit: second.  Interval for Errbot to refresh to list of available action aliases.
 }
@@ -114,13 +104,9 @@ Option | Description
 `api_auth.key` | Errbot API key to authenticate with StackStorm.  Used instead of a username/password pair or user token.
 `timer_update` | Unit: seconds.  Default is *60*. Interval for err-stackstorm to refresh to list of available action aliases.  (deprecated)
 `rbac_auth.standalone` | Standalone authentication.
-`rbac_auth.serverside` | Serverside authentication, err-stackstorm will request StackStorm credentials on behalf of a chat user from StackStorm.
 `rbac_auth.clientside` | Clientside authentication, a chat user will supply StackStorm credentials to err-stackstorm via an authentication page.
 `rbac_auth.clientside.url` | Url to the authentication web page.
 `secrets_store.cleartext` | Use the in memory store.
-`secrets_store.keyring` | Use the system's keyring store (_unavailable_).
-`secrets_store.keyring.keyring_password` | Password to unlock the keyring.
-`secrets_store.vault` | Use Hashicorp Vault store. (_unavailable_)
 
 ### Locale
 Errbot uses the systems locale for handling text, if your getting errors handling non ascii characters from chat
@@ -170,17 +156,9 @@ _API Key_ support has been included since StackStorm v2.0.  When an _API Key_ is
 The secrets store is used by err-stackstorm to cache StackStorm API credentials.  The available backends are:
 
  - `cleartext`
- - `keyring`
- - `vault`
 
 #### ClearText
-The `cleartext` store maintains the cache in memory and does not encrypt the contents to disk.  This is option doesn't protect the stored secrets.
-
-#### KeyRing
-The `keyring` store uses the systems keyring manager to create a namespace and write secrets to it.  Secrets are persisted to disk in an encrypted format.  The keyring must be unlocked when errbot is started.  [detail](http://man7.org/linux/man-pages/man7/keyrings.7.html)
-
-#### HashiCorp Vault
-The `vault` store uses Hashicorp's Vault to store secrets.  [details](https://www.vaultproject.io)
+The `cleartext` store maintains the cache in memory and does not encrypt the contents to disk.  This is option doesn't protect the stored secrets in memory.
 
 ### Role Based Access Control Authentication
 
@@ -198,26 +176,6 @@ original authentication method.
 ```
     'rbac_auth': {
         'standalone': {},
-    },
-```
-
-#### Server-side RBAC
-
-The "server-side" RBAC implementation uses err-stackstorm credentials to call the StackStorm API
-to pass chat service user identification.  The err-stackstorm credentials must be defined as a
-service.  Chat service user identifications must be registered with StackStorm before being used.
-
-When a chat service user matches, StackStorm will return the associated user token and err-stackstorm
-will cache the result.  When a chat user triggers an action-alias, the associated workflow will be
-executed with the cached user token.
-
-##### Configuration
-It is considered an error to have multiple RBAC authentication configurations present at the same time.
-Only the *serverside* key with an empty dictionary is required to enable Server-side RBAC for ChatOps.
-
-```
-    'rbac_auth': {
-        'serverside': {}
     },
 ```
 
@@ -245,13 +203,12 @@ using the associated StackStorm credentials.
 
 ##### Configuration
 It is considered an error to have both *extended* and *proxied* RBAC authentication configurations
-present at the same time.  A *proxied* key with *url* and *keyring_password* are required to correctly
+present at the same time.  A *proxied* key with *url* is required to correctly
 configure Out-of-bands authentication for ChatOps.
 ```
     'rbac_auth': {
         'clientside': {
             'url': 'https://<hostname>:<port>/',
-            'keyring_password': "<password>"
         }
     },
 ```
@@ -259,7 +216,6 @@ configure Out-of-bands authentication for ChatOps.
 Option | Description
 --- | ---
 `url` | Errbot's authentication web server end point.  Used for the out-of-bands authentication web page.
-`keyring_password` | The password used to unlock the keyring to read/write stored data.
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
+
 # err-stackstorm
 A plugin to run StackStorm actions, bringing StackStorm's ChatOps to Errbot.
 
 ## Table of Contents
-1. [Getting help](#GettingHelp)
+1. [Help](#Help)
 1. [Installation](#Installation)
 1. [Requirements](#Requirements)
 1. [Supported Chat Backends](#SupportedChatBackends)
@@ -13,11 +14,11 @@ A plugin to run StackStorm actions, bringing StackStorm's ChatOps to Errbot.
 1. [ChatOps Pack](#ChatOpsPack)
 1. [Troubleshooting](#Troubleshooting)
 
-## Getting help <a name="GettingHelp">
-You can find users of err-stackstorm on Gitter.  https://gitter.im/err-stackstorm/community or Slack https://stackstorm-community.slack.com `#err-stackstorm`
- 
+## Help <a name="GettingHelp">
+You can find users of err-stackstorm on Gitter.  https://gitter.im/err-stackstorm/community or Slack https://stackstorm-community.slack.com `#err-stackstorm`.  If you think you've found a bug or need a new feature open an issue on the [github repository](https://github.com/nzlosh/err-stackstorm/issues).  If you want to contribute to the err-stackstorm project, there's plenty of improvements to be made, contact nzlosh via chat or email to discuss how you can get involved.
+
 ## Installation <a name="Installation"></a>
-Installation of the err-stackstorm plugin is performed from within a running Errbot instance.  Ensure Errbot is up and running before attempting to install the plugin.  See the Errbot installation documentation here https://github.com/Errbotio/Errbot for instructions on how to setup Errbot on your chat back-end.  These instructions assume a running instance of StackStorm is already in place.  See the official [StackStorm documentation](https://docs.stackstorm.com/install/index.html) for details.
+Installation of the err-stackstorm plugin can be performed from within a running Errbot instance or from the command line using `git clone`.  Ensure Errbot is up and running before attempting to install the plugin.  See the Errbot installation documentation here https://github.com/Errbotio/Errbot for instructions on how to setup Errbot on your chat back-end.  These instructions assume a running instance of StackStorm is already in place.  See the official [StackStorm documentation](https://docs.stackstorm.com/install/index.html) for details.
 
  1. Install Errbot on the target system using standard package manager or Errbot installation method.
  1. Configure Errbot, see the [Configuration](#Configuration) section for help.
@@ -29,12 +30,14 @@ The below command will install the plugin.
 ```
 !repos install https://github.com/nzlosh/err-stackstorm.git
 ```
+*If errors are encountered, the plugin will fail to be installed.  Check the configuration is correct.*
 
 ## Requirements <a name="Requirements"></a>
 The plugin has been developed and tested against the below software.  For optimal operation it is recommended to use the following versions:
 
 plugin tag (version) | Python | Errbot | StackStorm client
 --- | --- | --- | ---
+2.1 | 3.6 | 6.0.0 | not used
 2.0 | 3.4 | 5.2.0 | 2.10
 1.4 | 3.4 | 5.1.2 | 2.5
 1.3 | 3.4 | 5.1.2 | 2.5
@@ -115,14 +118,14 @@ Option | Description
 `rbac_auth.clientside` | Clientside authentication, a chat user will supply StackStorm credentials to err-stackstorm via an authentication page.
 `rbac_auth.clientside.url` | Url to the authentication web page.
 `secrets_store.cleartext` | Use the in memory store.
-`secrets_store.keyring` | Use the system's keyring store.
+`secrets_store.keyring` | Use the system's keyring store (_unavailable_).
 `secrets_store.keyring.keyring_password` | Password to unlock the keyring.
-`secrets_store.vault` | Use Hashicorp Vault store.
+`secrets_store.vault` | Use Hashicorp Vault store. (_unavailable_)
 
 ### Locale
 Errbot uses the systems locale for handling text, if your getting errors handling non ascii characters from chat
 `UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in position 83: ordinal not in range(128)`
-Make sure the systems locale is using a unicode encoding, the `.UTF8` indicates the system encoding uses unicode.
+Make sure the systems locale is using a unicode encoding, which is indicted by the `.UTF8` extension.
 ```
 # locale
 LANG=en_NZ.UTF8
@@ -520,7 +523,7 @@ This indicates that the route wasn't set to `errbot`, see the Install ChatOps se
 
 ## Acknowledgements
 
-The err-stackstorm plugin was founded by (fmnisme)[https://github.com/fmnisme], thanks for starting the project.
+The err-stackstorm plugin was founded by [fmnisme](https://github.com/fmnisme), thanks for starting the project.
 
 ## Legal
 

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,14 +1,15 @@
-FROM alpine:3.8
+FROM alpine:3.8 as stage1
 MAINTAINER "nzlosh@yahoo.com"
 
-RUN apk add --no-cache python3 gcc python3-dev openssl-dev libffi-dev musl-dev git&& \
-	python3 -m ensurepip && \
-	rm -r /usr/lib/python*/ensurepip && \
-	pip3 install --upgrade pip setuptools && \
-	if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
-	if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
-	rm -r /root/.cache && \
-	pip3 install errbot && \
-	mkdir -p /opt/errbot && \
-	cd /opt/errbot && errbot --init
-ENTRYPOINT errbot -c /opt/errbot/config.py
+ENV ERRBOT_USER=errbot
+
+COPY docker_build_installer /root
+RUN sh /root/docker_build_installer stage1
+
+
+FROM alpine:3.8
+COPY docker_build_installer /root
+RUN sh /root/docker_build_installer stage2
+COPY --from=stage1 /opt/errbot /opt/errbot
+
+ENTRYPOINT /bin/sh

--- a/contrib/docker/docker_build_installer
+++ b/contrib/docker/docker_build_installer
@@ -1,0 +1,216 @@
+#!/bin/sh
+export ERRBOT=errbot
+
+function setup_account
+{
+    echo -e "\e[93mUser/Group\e[0m"
+    mkdir -p /opt/errbot
+    addgroup -S $ERRBOT_USER
+    adduser -S -g $ERRBOT -h /opt/errbot -s /bin/false $ERRBOT_USER
+    chown -R $ERRBOT:$ERRBOT /opt/errbot
+}
+
+function install_prod_packages
+{
+    echo -e "\e[93mPackage\e[0m"
+    apk add --no-cache py3-virtualenv python3 git openssl
+}
+
+function install_build_packages
+{
+    install_prod_packages
+    apk add --no-cache gcc python3-dev openssl-dev libffi-dev musl-dev
+    python3 -m ensurepip
+    rm -r /usr/lib/python*/ensurepip
+    test ! -e /usr/bin/pip && ln -s pip3 /usr/bin/pip
+    test ! -e /usr/bin/python && ln -sf /usr/bin/python3 /usr/bin/python
+    test -d /root/.cache && rm -r /root/.cache
+}
+
+function install_openssh
+{
+    echo -e "\e[93mCopy virtualenv to final image\e[0m"
+    apk add openssh
+    ssh-keygen -b 4096 -t ed25519 -f /etc/ssh/ssh_host_ed25519_key
+    echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
+
+}
+
+function setup_virtual_env
+{
+    echo -e "\e[93mVirtual Environment\e[0m"
+    virtualenv -p python3 /opt/errbot
+    source /opt/errbot/bin/activate
+}
+
+function install_plugin
+{
+    GIT_URL="$(echo ${1} | cut -d@ -f1)"
+    GIT_BRANCH="$(echo ${1} | cut -d@ -f2)"
+    PLUGIN_DIR="$(basename ${GIT_URL} | cut -d. -f1)"
+    cd /opt/errbot/plugins
+    git clone $GIT_URL
+    cd $PLUGIN_DIR
+    git checkout $GIT_BRANCH
+    pip install -r requirements.txt
+    pip install .
+}
+
+function install_backend
+{
+    GIT_URL="$(echo ${1} | cut -d@ -f1)"
+    GIT_BRANCH="$(echo ${1} | cut -d@ -f2)"
+    BACKEND_DIR="$(basename ${GIT_URL} | cut -d. -f1)"
+    cd /opt/errbot/backends
+    git clone $GIT_URL
+    cd $BACKEND_DIR
+    git checkout $GIT_BRANCH
+    pip install -r requirements.txt
+    pip install .
+    pip install trio
+    pip install trio-websocket
+}
+
+function initialise_errbot
+{
+    echo -e "\e[93mErrbot initialisation\e[0m"
+    cd /opt/errbot
+    errbot --init
+    cat <<xxEOFxx >/opt/errbot/config.py
+import logging
+BACKEND = 'Mattermost'
+BOT_DATA_DIR = r'/opt/errbot/data'
+BOT_EXTRA_PLUGIN_DIR = r'/opt/errbot/plugins'
+BOT_EXTRA_BACKEND_DIR = '/opt/errbot/backends'
+BOT_PREFIX = '.'
+
+# Gitter
+GITTER = {
+    'token' : '54537fa855b9a7bbbbbbbbbc568ea7c069d8c34d'
+}
+
+# Mattermost
+MATTERMOST = {
+    # Required
+    'team': 'everyone',
+    'server': '172.17.0.1',
+    # For the login, either
+    'login': 'prime',
+    'password': 'autobots',
+    # Or, if you have a personal access token
+    #'token': 'YourPersonalAccessToken',
+    # Optional
+    'insecure': False, # Default = False. Set to true for self signed certificates
+    'scheme': 'http', # Default = https
+    'port': 8065, # Default = 8065
+    'timeout': 30, # Default = 30. If the webserver disconnects idle connections later/earlier change this value
+    'cards_hook': 'incomingWebhookId' # Needed for cards/attachments
+}
+BOT_IDENTITY=MATTERMOST
+
+# Rocket.Chat
+ROCKETCHAT = {
+    "server_uri": "",
+    "login_username": "",
+    "login_password": ""
+}
+
+# Err-StackStorm
+STACKSTORM = {
+    'auth_url': 'https://192.168.7.113/auth/v1',
+    'api_url': 'https://192.168.7.113/api/v1',
+    'stream_url': 'https://192.168.7.113/stream/v1',
+
+    'verify_cert': False,
+    'secrets_store': 'cleartext',
+    'api_auth': {
+        'user': {
+            'name': 'st2admin',
+            'password': "winter",
+        },
+    },
+    'rbac_auth': {
+        'standalone': {}
+    },
+    'timer_update': 900, #  Unit: second.  Interval for Errbot to refresh to list of available action aliases.
+}
+
+BOT_LOG_FILE = r'/opt/errbot/errbot.log'
+BOT_LOG_LEVEL = logging.DEBUG
+
+BOT_ADMINS = ('prime', )
+
+class ROCKETCHAT_CONFIG(object):
+    """
+    Config object for AoikRocketChatErrbot.
+    Config values can be overridden by env variables. Config key `SERVER_URI`
+    maps to env variable name `AOIKROCKETCHATERRBOT_SERVER_URI`. Use string
+    '0', 'false' or 'no' to mean boolean false in env variable value.
+    """
+    SERVER_URI = 'ws://172.17.0.1:3000/websocket'
+    LOGIN_USERNAME = 'prime'
+    LOGIN_PASSWORD = 'autobots'
+    PATCH_METEOR_CLIENT = True
+    RECONNECT_ENABLED = True
+
+    HEARTBEAT_ENABLED = False
+    HEARTBEAT_INTERVAL = 10
+    @classmethod
+    def _heartbeat_func(cls, backend):
+        """
+        Heartbeat function.
+        :param backend: Backend object.
+        :return: None.
+        """
+        msg = 'Heartbeat: {}'.format(datetime.now().strftime('%H:%M:%S'))
+        backend.send_rocketchat_message(
+            params={
+                'rid': 'GENERAL',
+                'msg': msg,
+            }
+        )
+    HEARTBEAT_FUNC = _heartbeat_func
+BOT_LOG_LEVEL = logging.DEBUG
+xxEOFxx
+}
+
+function install_errbot
+{
+    echo -e "\e[93mErrbot plugins installation\e[0m"
+    pip3 install --upgrade pip setuptools
+    pip3 install errbot
+    initialise_errbot
+    mkdir -p /opt/errbot/plugins/
+    mkdir -p /opt/errbot/backends/
+    for plugin in 'https://github.com/nzlosh/err-stackstorm.git'
+    do
+        install_plugin $plugin
+    done
+
+    for backend in 'https://github.com/nzlosh/err-backend-rocketchat.git@maint_nzlosh' 'https://github.com/nzlosh/err-backend-gitter.git@maint_nzlosh' 'https://github.com/nzlosh/err-backend-discord.git@maint_nzlosh' 'https://github.com/nzlosh/err-backend-mattermost.git@maint_nzlosh'
+    do
+        install_backend $backend
+    done
+}
+
+function stage1_build
+{
+    setup_account
+    install_build_packages
+    setup_virtual_env
+    install_errbot
+}
+
+function stage2_build
+{
+    setup_account
+    install_prod_packages
+    install_openssh
+}
+
+if [ "$1" == "stage1" ]
+then
+    stage1_build
+else
+    stage2_build
+fi

--- a/docs/out_of_band_authentication.md
+++ b/docs/out_of_band_authentication.md
@@ -29,15 +29,10 @@ credentials store and provide the corresponding StackStorm user token/api key to
 
 Nginx is used as a reverse proxy to errbot's webserver.  Nginx should perform TLS and authentication.
 
-### vault
-
-### keyring
-
 #### limitation
-must unlock the keyring manually when the bot starts.
+
+Clear text in memory doesn't provides weak secret protection.
 
 ### security considerations
 
-use ssl client certificates for auth page.
-keyring should be considered a weak security mechanism.
-
+Use ssl client certificates for auth page.

--- a/lib/config.py
+++ b/lib/config.py
@@ -32,7 +32,7 @@ class PluginConfiguration(BorgSingleton):
         self.oob_auth_url = bot_conf.STACKSTORM.get("oob_auth_url", "https://localhost:8888/")
         self.timer_update = bot_conf.STACKSTORM.get("timer_update", 60)
         self.verify_cert = bot_conf.STACKSTORM.get("verify_cert", True)
-        self.secrets_store = bot_conf.STACKSTORM.get("secrets_store", "keyring")
+        self.secrets_store = bot_conf.STACKSTORM.get("secrets_store", "cleartext")
 
         self.client_cert = bot_conf.STACKSTORM.get("client_cert", None)
         self.client_key = bot_conf.STACKSTORM.get("client_key", None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 requests>=2.20.0
 sseclient-py
 sseclient
-keyring
-hvac

--- a/test_err-stackstorm.py
+++ b/test_err-stackstorm.py
@@ -7,8 +7,7 @@ from mock import Mock
 from lib.session import Session
 from lib.session_manager import SessionManager
 from lib.credentials_adapters import CredentialsFactory
-from lib.store_adapters import ClearTextStoreAdapter, KeyringStoreAdapter, VaultStoreAdapter, \
-    StoreAdapterFactory
+from lib.store_adapters import ClearTextStoreAdapter, StoreAdapterFactory
 from lib.errors import SessionExpiredError, SessionInvalidError, SessionConsumedError, \
     SessionExistsError
 
@@ -26,16 +25,9 @@ def test_secret_store():
     cleartext = StoreAdapterFactory.instantiate("cleartext")
     assert isinstance(cleartext, ClearTextStoreAdapter)
 
-    keyring = StoreAdapterFactory.instantiate("keyring")
-    assert isinstance(keyring, KeyringStoreAdapter)
-
-    vault = StoreAdapterFactory.instantiate("vault")
-    assert isinstance(vault, VaultStoreAdapter)
-
     # set a secret
     cleartext.set("token", st2_token)
-    keyring.set("token", st2_token)
-    valut.set("token", st2_token)
+
     # get a secret
 
     # list secrets


### PR DESCRIPTION
Keyring and Vault adapters were planned to be used to store secrets but were either unimplemented or causes too many issue during the installation of the err-stackstorm plugin.