### PR TITLE
Add TTL support to configuration - fixes #27

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, err-stackstorm contributors'
 author = 'err-stackstorm contributors'
 
 # The full version, including alpha/beta/rc tags
-release = '2.1'
+release = '2.1.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -164,11 +164,11 @@ Reference
     "api_auth.user.password", "Errbot's password to authenticate with StackStorm."
     "api_auth.token", "Errbot's user token to authenticate with StackStorm. Used instead of a username/password pair."
     "api_auth.apikey", "Errbot API key to authenticate with StackStorm. Used instead of a username/password pair or user token."
-    "timer_update", "Unit: seconds. Default is 60. Interval to test if err-stackstorm's user token is valid."
+    "timer_update", "Unit: seconds. Default: 60.  Interval for err-stackstorm to the user token is valid."
     "rbac_auth.standalone", "Standalone authentication."
     "rbac_auth.clientside", "Clientside authentication, a chat user will supply StackStorm credentials to err-stackstorm via an authentication page."
     "rbac_auth.clientside.url", "Url to the authentication web page."
-    "secrets_store.cleartext", "Use the in memory store."
-
-
+    "session_ttl", "Unit: seconds.  Default: 3600.  The time to live for a authentication session."
+    "user_token_ttl", "Unit: seconds. Default: 86400.  The time to live for a StackStorm user token."
+    "secrets_store.cleartext", "Use the in-memory store."
 

--- a/html/index.html
+++ b/html/index.html
@@ -6,7 +6,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.3.3/semantic.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-serialize-object/2.5.0/jquery.serialize-object.min.js"></script>
     <script>
-        console.log("err-stackstorm v2.1.1")
+        console.log("err-stackstorm v2.1.3")
         function get_uuid_from_querystring(){
             uuid = undefined;
             params = window.location.href.split("?");

--- a/lib/authentication_controller.py
+++ b/lib/authentication_controller.py
@@ -132,7 +132,7 @@ class AuthenticationController(object):
         Handle an initial request to establish a session.  If a session already exists, return it.
         """
         user_id = self.to_userid(user)
-        return self.sessions.create(user_id, user_secret)
+        return self.sessions.create(user_id, user_secret, self.bot.cfg.session_ttl)
 
     def get_session(self, user):
         """

--- a/lib/authentication_controller.py
+++ b/lib/authentication_controller.py
@@ -1,7 +1,5 @@
 # coding:utf-8
-import string
 import logging
-from random import SystemRandom
 
 from lib.session_manager import SessionManager
 from lib.session import generate_password
@@ -132,7 +130,7 @@ class AuthenticationController(object):
         Handle an initial request to establish a session.  If a session already exists, return it.
         """
         user_id = self.to_userid(user)
-        return self.sessions.create(user_id, user_secret)
+        return self.sessions.create(user_id, user_secret, self.bot.cfg.session_ttl)
 
     def get_session(self, user):
         """

--- a/lib/authentication_controller.py
+++ b/lib/authentication_controller.py
@@ -4,17 +4,11 @@ import logging
 from random import SystemRandom
 
 from lib.session_manager import SessionManager
+from lib.session import generate_password
 from lib.errors import SessionInvalidError
 from errbot.backends.base import Identifier
 
 LOG = logging.getLogger("errbot.plugin.st2.auth_ctrl")
-
-
-def generate_password(length=8):
-    rnd = SystemRandom()
-    if length > 255:
-        length = 255
-    return "".join([rnd.choice(string.hexdigits) for _ in range(length)])
 
 
 class BotPluginIdentity(object):

--- a/lib/authentication_handler.py
+++ b/lib/authentication_handler.py
@@ -109,7 +109,7 @@ class StandaloneAuthHandler(BaseAuthHandler):
             self.cfg.auth_url,
             path="/tokens",
             headers=st2_creds.requests(),
-            payload={"ttl": 86400}
+            payload={"ttl": self.cfg.user_token_ttl}
         )
         if response.status_code in [requests.codes.created]:
             return St2UserToken(response.json().get("token"))
@@ -323,7 +323,7 @@ class ClientSideAuthHandler(BaseAuthHandler):
             self.cfg.auth_url,
             path="/tokens",
             headers=creds.requests(),
-            payload={"ttl": 86400}
+            payload={"ttl": self.user_token_ttl}
         )
         if response.status_code in [requests.codes.created]:
             return St2UserToken(response.json().get("token"))

--- a/lib/config.py
+++ b/lib/config.py
@@ -27,8 +27,8 @@ class PluginConfiguration(BorgSingleton):
         if not hasattr(bot_conf, "STACKSTORM"):
             LOG.critical(
                 "Missing STACKSTORM configuration in config.py.   err-stackstorm must be configured"
-                " correctly to function.  For configuration insturction visit the err-stackstorm"
-                " homepage."
+                " correctly to function.  See the err-stackstorm documentation for configuration "
+                "instructions."
             )
             bot_conf.__setattr__("STACKSTORM", {})
         self._configure_prefixes(bot_conf)
@@ -40,6 +40,8 @@ class PluginConfiguration(BorgSingleton):
         self.verify_cert = bot_conf.STACKSTORM.get("verify_cert", True)
         self.secrets_store = bot_conf.STACKSTORM.get("secrets_store", "cleartext")
         self.route_key = bot_conf.STACKSTORM.get("route_key", "errbot")
+        self.session_ttl = bot_conf.STACKSTORM.get("session_ttl", 3600)
+        self.user_token_ttl = bot_conf.STACKSTORM.get("user_token_ttl", 86400)
 
         self.client_cert = bot_conf.STACKSTORM.get("client_cert", None)
         self.client_key = bot_conf.STACKSTORM.get("client_key", None)

--- a/lib/session.py
+++ b/lib/session.py
@@ -18,14 +18,14 @@ def generate_password(length=8):
 
 
 class Session(object):
-    def __init__(self, user_id, user_secret):
+    def __init__(self, user_id, user_secret, session_ttl):
         self.bot_secret = None
         self.user_id = user_id
         self._is_sealed = True
         self.session_id = uuid.uuid4()
         self.create_date = int(dt.now().timestamp())
         self.modified_date = self.create_date
-        self.ttl_in_seconds = 3600
+        self.ttl_in_seconds = session_tt
         self._hashed_secret = self.hash_secret(user_secret)
         del user_secret
 

--- a/lib/session.py
+++ b/lib/session.py
@@ -18,14 +18,14 @@ def generate_password(length=8):
 
 
 class Session(object):
-    def __init__(self, user_id, user_secret):
+    def __init__(self, user_id, user_secret, session_ttl=3600):
         self.bot_secret = None
         self.user_id = user_id
         self._is_sealed = True
         self.session_id = uuid.uuid4()
         self.create_date = int(dt.now().timestamp())
         self.modified_date = self.create_date
-        self.ttl_in_seconds = 3600
+        self.ttl_in_seconds = session_ttl
         self._hashed_secret = self.hash_secret(user_secret)
         del user_secret
 

--- a/lib/session_manager.py
+++ b/lib/session_manager.py
@@ -35,7 +35,7 @@ class SessionManager(object):
             raise SessionInvalidError
         return session
 
-    def create(self, user_id, user_secret):
+    def create(self, user_id, user_secret, session_ttl):
         """
         param: user_id - Chat user unique identifier.
         param: user_secret - A pseudo-secret word provided by
@@ -44,7 +44,7 @@ class SessionManager(object):
         # Don't create a new session if one already exists.
         if self.exists(user_id):
             raise SessionExistsError
-        session = Session(user_id, user_secret)
+        session = Session(user_id, user_secret, session_ttl)
         # Store the session.
         self.store.put(session)
         return session

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import setuptools
 
 setuptools.setup(
     name="err-stackstorm",
-    version="2.1.0-rc2",
+    version="2.1.3",
     author="Err-StackStorm Plugin contributors",
     author_email="nzlosh@yahoo.com",
     description="An Errbot plugin for StackStorm ChatOps.",

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -22,6 +22,7 @@ def test_session_manager():
     user_id = 'test%user'
     user_secret = 'secret_for_test'
     user_token = '1234567890-0987654321'
+    session_ttl = 5000
 
     session_manager = SessionManager(cfg)
 
@@ -29,7 +30,7 @@ def test_session_manager():
     assert isinstance(session_manager.secure_store, ClearTextStoreAdapter)
 
     # create a new user
-    s = session_manager.create(user_id, user_secret)
+    s = session_manager.create(user_id, user_secret, session_ttl)
     assert s.user_id == user_id
 
     # 1 session in list
@@ -37,7 +38,7 @@ def test_session_manager():
 
     # create same user raise exception
     with pytest.raises(SessionExistsError):
-        session_manager.create(user_id, user_secret)
+        session_manager.create(user_id, user_secret, session_ttl)
 
     # get an existing session
     s1 = session_manager.get_by_uuid(s.id())


### PR DESCRIPTION
Expose session ttl and stackstorm user token ttl in err-stackstorm configuration.
Updated documentation for route key and plugin_prefix options.