### PR TITLE
Drop text of bot prefix only if it is a prefix

### DIFF
--- a/src/err-stackstorm/st2.py
+++ b/src/err-stackstorm/st2.py
@@ -322,7 +322,7 @@ class St2(BotPlugin):
             """
             Drop plugin prefix and any trailing white space from user supplied st2 command.
             """
-            return msg.replace(self.cfg.plugin_prefix, "", 1).strip()
+            return msg.removeprefix(self.cfg.plugin_prefix).strip()
 
         chat_user = msg.frm
         st2token, err_msg = self.get_token(chat_user)


### PR DESCRIPTION
Currently if a command string contains the text of the plugin name, but it is not the prefix, it will still get stripped from the command string, for example:

If the command is "hello wombats are great"

and the bot prefix is "wombat"

it would strip the command to "hello s are great"

With this change it will only strip the bot/plugin prefix from the command string if it appears as the first part of the string.